### PR TITLE
Updated .travis.yml to support tests for go 1.6, removed support for go 1.4.3 in tests, removed getting of go vet from test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ services:
 - docker
 language: go
 go:
-- 1.4.3
 - 1.5.3
+- 1.6
 before_install:
 - go get github.com/tools/godep
 - if [ ! -d $SNAP_PLUGIN_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $SNAP_PLUGIN_SOURCE; fi # CI for forks not from intelsdi-x

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It's used in the [snap framework](http://github.com:intelsdi-x/snap).
 To get started, you'll need snap and OpenTSDB running to receive and aggregate sampling data points.
 
 ### System Requirements
-* [golang 1.4+](https://golang.org/dl/)
+* [golang 1.5+](https://golang.org/dl/) (needed only for building)
 * [snap](https://github.com/intelsdi-x/snap)
 
 ### Operating systems

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -32,7 +32,6 @@ if [[ $TEST_SUITE == "unit" ]]; then
 	go get github.com/axw/gocov/gocov
 	go get github.com/mattn/goveralls
 	go get -u github.com/golang/lint/golint
-	go get golang.org/x/tools/cmd/vet
 	go get golang.org/x/tools/cmd/goimports
 	go get github.com/smartystreets/goconvey/convey
 	go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
Supported golang in .travis.yml has been updated.
Removed go vet import because of this [commit](https://github.com/golang/tools/commit/adaaa074861b0d254acf51dec74daf7c2ba20e90), without updating test.sh it is not possible to successfully execute tests.